### PR TITLE
Removed parameter from nice counter function

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ client.on('messageReactionAdd', (messageReaction, user) => {
     }
 })
 
-function niceCounter(message, niceCount){
+function niceCounter(message){
   
     if(message.includes("69")&&message.includes("420")){
       niceCount += 2;


### PR DESCRIPTION
This should now force the function to address the global, persistent variable

Closes #19 